### PR TITLE
Add generate_background method to StimulusBuilder for background acti…

### DIFF
--- a/bmtool/stimulus/core.py
+++ b/bmtool/stimulus/core.py
@@ -140,16 +140,129 @@ class StimulusBuilder:
             raise ValueError(f"Unknown distribution: {distribution}. Must be 'lognormal' or 'normal'.")
         
         return rates
+    
+    def generate_background(self, output_path, network_name, population_params,
+                           groupby='pop_name', t_start=0.0, t_stop=10.0, 
+                           verbose=False, seed=None):
+        """Generate background (spontaneous) activity for network nodes grouped by property.
+        
+        This function generates baseline spiking activity, grouped by a specified node property.
+        Each group can use either a constant firing rate or a distribution-based rate.
+        
+        Args:
+            output_path (str): Path to save the resulting .h5 file.
+            network_name (str): BMTK network name.
+            population_params (dict): Parameters for each population/group.
+                Keys should match values in the node property specified by groupby.
+                Each value is a dict with:
+                    - 'mean_firing_rate' (float): Mean firing rate in Hz (required)
+                    - 'stdev' (float, optional): Standard deviation. If provided, uses lognormal distribution.
+                                                If omitted, uses constant firing rate.
+                Example:
+                    {
+                        'PN': {'mean_firing_rate': 20.0, 'stdev': 2.0},
+                        'PV': {'mean_firing_rate': 30.0},  # constant rate
+                        'SST': {'mean_firing_rate': 15.0, 'stdev': 1.5}
+                    }
+            groupby (str): Node property to group by (default: 'pop_name').
+                          Will match against keys in population_params.
+            t_start, t_stop (float): Time range for activity (seconds).
+            verbose (bool): If True, print detailed information (default: False).
+            seed (int, optional): Random seed for distribution sampling. Overrides instance psg_seed.
+            
+        Examples:
+            # Population-specific rates with mixed distributions
+            params = {
+                'PN': {'mean_firing_rate': 20.0, 'stdev': 2.0},
+                'PV': {'mean_firing_rate': 30.0},  # constant rate
+                'SST': {'mean_firing_rate': 15.0, 'stdev': 1.5}
+            }
+            sb.generate_background(
+                output_path='background.h5',
+                network_name='input',
+                population_params=params,
+                t_start=0.0, t_stop=15.0
+            )
+            
+            # Group by custom property (e.g., layer)
+            layer_params = {
+                'L1': {'mean_firing_rate': 10.0, 'stdev': 1.0},
+                'L2/3': {'mean_firing_rate': 15.0, 'stdev': 2.0}
+            }
+            sb.generate_background(
+                output_path='layer_background.h5',
+                network_name='input',
+                population_params=layer_params,
+                groupby='layer'
+            )
+        """
+        if population_params is None or not isinstance(population_params, dict):
+            raise ValueError("population_params must be a non-empty dict")
+        
+        nodes_df = self.get_nodes(network_name)
+        
+        # Verify groupby column exists
+        if groupby not in nodes_df.columns:
+            raise ValueError(f"Node property '{groupby}' not found in network '{network_name}'")
+        
+        # Use provided seed or default to instance psg_seed
+        psg_seed = seed if seed is not None else self.psg_seed
+        
+        population = network_name  # Default population name in PSG
+        psg = PoissonSpikeGenerator(population=population, seed=psg_seed)
+        
+        times = (t_start, t_stop)
+        total_nodes = 0
+        
+        for group_key, params in population_params.items():
+            # Find nodes matching this group
+            nodes_in_group = nodes_df[nodes_df[groupby] == group_key].index.values
+            
+            if len(nodes_in_group) == 0:
+                if verbose:
+                    print(f"  Warning: No nodes found with {groupby}='{group_key}'")
+                continue
+            
+            total_nodes += len(nodes_in_group)
+            
+            if not isinstance(params, dict) or 'mean_firing_rate' not in params:
+                raise ValueError(f"params['{group_key}'] must be a dict with 'mean_firing_rate' key")
+            
+            mean_rate = params['mean_firing_rate']
+            stdev = params.get('stdev', None)
+            
+            # Determine: constant vs distribution-based
+            if stdev is not None:
+                # Use distribution (lognormal)
+                firing_rates = self._generate_firing_rates(len(nodes_in_group), mean_rate, stdev, 'lognormal')
+                for node_id, rate in zip(nodes_in_group, firing_rates):
+                    psg.add(node_ids=node_id, firing_rate=rate, times=times)
+                if verbose:
+                    print(f"  {group_key}: {len(nodes_in_group)} nodes, {mean_rate:.1f}±{stdev:.1f} Hz (lognormal)")
+            else:
+                # Use constant firing rate
+                psg.add(node_ids=nodes_in_group.tolist(), firing_rate=mean_rate, times=times)
+                if verbose:
+                    print(f"  {group_key}: {len(nodes_in_group)} nodes, {mean_rate:.1f} Hz (constant)")
+        
+        # Write to file
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        psg.to_sonata(output_path)
+        if verbose:
+            print(f"Generated background activity: {total_nodes} nodes to {output_path}")
             
     def generate_stimulus(self, output_path, pattern_type, assembly_name, verbose=False, seed=None, **kwargs):
         """Generate a BMTK Poisson spike file (SONATA) for a specific assembly group.
+        
+        Use create_assemblies() first to define your stimulus assemblies, then call this
+        function to generate time-varying firing patterns for those assemblies.
         
         Args:
             output_path (str): Path to save the resulting .h5 file.
             pattern_type (str): Firing rate template ('short', 'long', 'ramp', etc).
             assembly_name (str): Name of the assembly group created via create_assemblies.
             verbose (bool): If True, print detailed information (default: False).
-            seed (int, optional): Random seed for Poisson spike generation. Overrides instance psg_seed for this call.
+            seed (int, optional): Random seed for Poisson spike generation. Overrides instance psg_seed.
             **kwargs: Arguments passed to the generator function and PoissonSpikeGenerator.
                 - population (str): Name of the spike population (for BMTK).
                 - firing_rate (3-tuple): (off_rate, burst_rate, silent_rate).
@@ -157,9 +270,20 @@ class StimulusBuilder:
                 - off_time (float): Duration of silent period.
                 - t_start (float): Start time of cycles.
                 - t_stop (float): End time of cycles.
+                
+        Example:
+            # First create assemblies
+            sb.create_assemblies(name='stim_groups', network_name='thalamus', 
+                                method='property', property_name='pulse_group_id')
+            
+            # Then generate stimulus
+            sb.generate_stimulus(output_path='stim.h5', pattern_type='long', 
+                                assembly_name='stim_groups', population='thalamus',
+                                firing_rate=(0.0, 50.0, 0.0), t_start=1.0, t_stop=15.0,
+                                on_time=1.0, off_time=0.5)
         """
         if assembly_name not in self.assemblies:
-            raise ValueError(f"Assembly '{assembly_name}' not defined.")
+            raise ValueError(f"Assembly '{assembly_name}' not defined. Use create_assemblies() first.")
             
         assembly_list = self.assemblies[assembly_name]
         n_assemblies = len(assembly_list)
@@ -192,99 +316,3 @@ class StimulusBuilder:
         psg.to_sonata(output_path)
         if verbose:
             print(f"Written stimulus to {output_path}")
-
-    def generate_baseline(self, output_path, network_name, pop_name=None, distribution='constant', 
-                         mean=None, stdev=None, firing_rate=None, t_start=0.0, t_stop=10.0, verbose=False, seed=None):
-        """Generate baseline activity for a selection of nodes.
-        
-        Args:
-            output_path (str): Path to save the resulting .h5 file.
-            network_name (str): BMTK network name.
-            pop_name (str, optional): Filter nodes by population name.
-            distribution (str): 'constant', 'lognormal', or 'normal'.
-            mean (float): Mean for lognormal/normal or constant rate (if firing_rate omitted).
-            stdev (float): Standard deviation for lognormal/normal.
-            firing_rate (float, optional): Constant firing rate.
-            t_start, t_stop (float): Time range for activity.
-            verbose (bool): If True, print detailed information (default: False).
-            seed (int, optional): Random seed for distribution sampling. Overrides instance psg_seed for this call.
-        """
-        nodes_df = self.get_nodes(network_name, pop_name)
-        node_ids = nodes_df.index.values.tolist()
-        
-        # Use provided seed or default to instance psg_seed
-        psg_seed = seed if seed is not None else self.psg_seed
-        
-        population = network_name # Default population name in PSG
-        psg = PoissonSpikeGenerator(population=population, seed=psg_seed)
-        
-        times = (t_start, t_stop)
-        
-        if distribution == 'constant':
-            if firing_rate is None:
-                if mean is not None: 
-                    firing_rate = mean
-                else:
-                    raise ValueError("Must provide firing_rate for constant distribution")
-            
-            psg.add(node_ids=node_ids, firing_rate=firing_rate, times=times)
-            
-        elif distribution in ['lognormal', 'normal']:
-            if mean is None or stdev is None:
-                raise ValueError(f"Must provide mean and stdev for {distribution} distribution")
-            
-            firing_rates = self._generate_firing_rates(len(node_ids), mean, stdev, distribution)
-            
-            for node_id, fr in zip(node_ids, firing_rates):
-                psg.add(node_ids=node_id, firing_rate=fr, times=times)
-                
-        else:
-             raise ValueError(f"Unknown distribution: {distribution}")
-             
-        # Write to file
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        psg.to_sonata(output_path)
-        if verbose:
-            print(f"Written baseline to {output_path}")
-
-    def generate_shell_input(self, output_path, network_name, shell_params, 
-                            distribution='lognormal', t_start=0.0, t_stop=15.0, verbose=False, seed=None):
-        """Generate shell (background) stimulus with population-specific rates.
-        
-        Args:
-            output_path (str): Path to save the resulting .h5 file.
-            network_name (str): BMTK network name.
-            shell_params (dict): Population-specific (mean, stdev) tuples.
-                Example: {'ET': (1.9, 1.8), 'IT': (1.3, 1.4), 'PV': (7.5, 6.4), 'SST': (5.0, 6.0)}
-            distribution (str): 'lognormal' or 'normal' (default: 'lognormal').
-            t_start, t_stop (float): Time range for activity.
-            verbose (bool): If True, print detailed information (default: False).
-            seed (int, optional): Random seed for distribution sampling. Overrides instance psg_seed for this call.
-        """
-        nodes_df = self.get_nodes(network_name)
-        
-        # Use provided seed or default to instance psg_seed
-        psg_seed = seed if seed is not None else self.psg_seed
-        
-        psg = PoissonSpikeGenerator(population=network_name, seed=psg_seed)
-        
-        total_nodes = 0
-        for pop_name, (mean, stdev) in shell_params.items():
-            nodes_in_pop = nodes_df[nodes_df['pop_name'] == pop_name].index.values
-            if len(nodes_in_pop) == 0:
-                continue
-            
-            total_nodes += len(nodes_in_pop)
-            
-            # Generate rates using helper function
-            rates = self._generate_firing_rates(len(nodes_in_pop), mean, stdev, distribution)
-            
-            # Add to PSG
-            for node_id, rate in zip(nodes_in_pop, rates):
-                psg.add(node_ids=node_id, firing_rate=rate, times=(t_start, t_stop))
-        
-        # Write to file
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        psg.to_sonata(output_path)
-        if verbose:
-            print(f"Generated shell stimulus ({distribution}): {total_nodes} nodes to {output_path}")

--- a/docs/api/stimulus.md
+++ b/docs/api/stimulus.md
@@ -5,6 +5,13 @@
 ### StimulusBuilder
 
 ::: bmtool.stimulus.core.StimulusBuilder
+    options:
+      members:
+        - __init__
+        - get_nodes
+        - create_assemblies
+        - generate_background
+        - generate_stimulus
 
 ## Firing Rate Generators
 

--- a/docs/examples/notebooks/stimulus/stimulus_tutorial.ipynb
+++ b/docs/examples/notebooks/stimulus/stimulus_tutorial.ipynb
@@ -108,12 +108,15 @@
    "outputs": [],
    "source": [
     "baseline_file = os.path.join(output_dir, 'baseline.h5')\n",
-    "sb.generate_baseline(\n",
+    "\n",
+    "baseline_params = {\n",
+    "    'base': {'mean_firing_rate': 20.0, 'stdev': 2.0}\n",
+    "}\n",
+    "\n",
+    "sb.generate_background(\n",
     "    output_path=baseline_file,\n",
     "    network_name='baseline',\n",
-    "    distribution='lognormal',\n",
-    "    mean=20.0,\n",
-    "    stdev=2.0,\n",
+    "    population_params=baseline_params,\n",
     "    t_start=0.0,\n",
     "    t_stop=15.0\n",
     ")"
@@ -124,9 +127,9 @@
    "id": "9412fc70",
    "metadata": {},
    "source": [
-    "## Analyze Baseline Firing Rates\n",
+    "## Verify Shell Input Statistics\n",
     "\n",
-    "Load the baseline stimulus and visualize the firing rate distribution."
+    "Load shell spikes and visualize population-specific firing rate statistics. Each population (PN, PV, SST) can have its own firing rate distribution."
    ]
   },
   {
@@ -136,16 +139,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "baseline_h5 = os.path.join(output_dir, 'baseline.h5')\n",
-    "spikes_df = load_spikes_to_df(baseline_h5, network_name='baseline', config=config_path)\n",
+    "shell_file = os.path.join(output_dir, 'shell.h5')\n",
     "\n",
-    "pop_stats, individual_stats = compute_firing_rate_stats(spikes_df)\n",
-    "plt.figure(figsize=(10, 6))\n",
-    "plot_firing_rate_histogram(individual_stats, bins=50)\n",
-    "plt.title('Firing Rate Distribution of Baseline Input Cells')\n",
-    "plt.xlabel('Firing Rate (Hz)')\n",
-    "plt.ylabel('Number of Cells')\n",
-    "plt.show()"
+    "shell_params = {\n",
+    "    'PN': {'mean_firing_rate': 1.9, 'stdev': 1.8},\n",
+    "    'PV': {'mean_firing_rate': 7.5, 'stdev': 6.4},\n",
+    "    'SST': {'mean_firing_rate': 5.0, 'stdev': 6.0}\n",
+    "}\n",
+    "\n",
+    "sb.generate_background(\n",
+    "    output_path=shell_file,\n",
+    "    network_name='shell',\n",
+    "    population_params=shell_params,\n",
+    "    t_start=0.0,\n",
+    "    t_stop=15.0\n",
+    ")"
    ]
   },
   {
@@ -255,6 +263,19 @@
    "source": [
     "long_file = os.path.join(output_dir, 'long.h5')\n",
     "\n",
+    "# First, create assemblies from node properties\n",
+    "sb.create_assemblies(\n",
+    "    name='thalamus_groups',\n",
+    "    network_name='thalamus',\n",
+    "    method='property',\n",
+    "    property_name='pulse_group_id'\n",
+    ")\n",
+    "\n",
+    "assembly_list = sb.assemblies['thalamus_groups']\n",
+    "n_assemblies = len(assembly_list)\n",
+    "print(f\"Created {n_assemblies} assemblies from pulse_group_id\")\n",
+    "\n",
+    "# Then generate stimulus using the assembly name\n",
     "firing_rate_params = (0.0, 50.0, 0.0)  # (off_rate, burst_rate, silent_rate)\n",
     "\n",
     "sb.generate_stimulus(\n",
@@ -265,7 +286,7 @@
     "    firing_rate=firing_rate_params,\n",
     "    t_start=1.0,\n",
     "    t_stop=15.0,\n",
-    "    on_time=1.0, \n",
+    "    on_time=1.0,\n",
     "    off_time=0.5\n",
     ")"
    ]
@@ -406,12 +427,12 @@
     "sb.generate_stimulus(\n",
     "    output_path=short_file,\n",
     "    pattern_type='short',\n",
-    "    assembly_name='thalamus_groups',\n",
+    "    assembly_name='thalamus_groups',  # Use the same assembly created earlier\n",
     "    population='thalamus',\n",
     "    firing_rate=firing_rate_params,\n",
     "    t_start=1.0,\n",
     "    t_stop=15.0,\n",
-    "    on_time=1.0, \n",
+    "    on_time=1.0,\n",
     "    off_time=0.5\n",
     ")"
    ]
@@ -445,15 +466,17 @@
     "\n",
     "This tutorial demonstrated the key features of the `StimulusBuilder` module:\n",
     "\n",
-    "1. **Baseline Activity**: Generate static, population-wide background activity with customizable firing rate distributions (lognormal, normal, constant).\n",
+    "1. **Unified Background Generation**: Use `generate_background()` with `population_params` to create activity grouped by any node property (pop_name, layer, etc).\n",
     "\n",
-    "2. **Population-Specific Shell Input**: Create background activity tailored to different cell types with independent firing rate parameters.\n",
+    "2. **Flexible Distribution Types**: Each group can independently use either constant rates or statistical distributions (lognormal, normal). Omit `stdev` for constant-rate groups.\n",
     "\n",
-    "3. **Assembly-Based Stimulus Generation**: Partition neurons into groups using multiple strategies (random, property-based, grid-based) and deliver coordinated stimulus patterns.\n",
+    "3. **Property-Based Grouping**: Control how nodes are grouped using the `groupby` parameter (default: 'pop_name'). This allows grouping by cell type, layer, region, or custom properties.\n",
     "\n",
-    "4. **Firing Rate Patterns**: Use different temporal patterns ('long' vs 'short') to deliver precisely timed stimuli to neural assemblies.\n",
+    "4. **Assembly-Based Stimulus Generation**: Partition neurons into groups using multiple strategies (random, property-based, grid-based) and deliver coordinated stimulus patterns.\n",
     "\n",
-    "5. **Validation and Analysis**: Verify generated stimuli using firing rate statistics, histograms, and raster plots to ensure they meet your experimental design requirements.\n",
+    "5. **Firing Rate Patterns**: Use different temporal patterns ('long' vs 'short') to deliver precisely timed stimuli to neural assemblies.\n",
+    "\n",
+    "6. **Validation and Analysis**: Verify generated stimuli using firing rate statistics, histograms, and raster plots to ensure they meet your experimental design requirements.\n",
     "\n",
     "Explore other firing patterns ('ramp', 'join', 'fade', 'loop') in the [Stimulus Module Overview](../../modules/stimulus.md) to further customize stimulus delivery for your simulations."
    ]

--- a/docs/examples/stimulus.md
+++ b/docs/examples/stimulus.md
@@ -49,18 +49,22 @@ from bmtool.stimulus.core import StimulusBuilder
 
 sb = StimulusBuilder(config='your_config.json', net_seed=123, psg_seed=1)
 
-# Generate baseline
-sb.generate_baseline(output_path='baseline.h5', network_name='input', 
-                     distribution='lognormal', mean=20.0, stdev=2.0,
-                     t_start=0.0, t_stop=15.0)
+# Generate background with mixed distribution types
+params = {
+    'PN': {'mean_firing_rate': 20.0, 'stdev': 2.0},     # lognormal
+    'PV': {'mean_firing_rate': 30.0},                    # constant
+    'SST': {'mean_firing_rate': 15.0, 'stdev': 1.5}    # lognormal
+}
+sb.generate_background(output_path='background.h5', network_name='input',
+                       population_params=params, t_start=0.0, t_stop=15.0)
 
-# Create assemblies
-sb.create_assemblies(name='stim_groups', network_name='input', 
-                    method='random', n_assemblies=5)
+# Generate stimulus: create assemblies first
+sb.create_assemblies(name='stim_groups', network_name='thalamus', 
+                    method='property', property_name='pulse_group_id')
 
-# Generate stimulus
+# Then generate stimulus patterns
 sb.generate_stimulus(output_path='stimulus.h5', pattern_type='long',
-                    assembly_name='stim_groups', population='stimulus',
+                    assembly_name='stim_groups', population='thalamus',
                     firing_rate=(0.0, 50.0, 0.0), t_start=1.0, t_stop=15.0,
                     on_time=1.0, off_time=0.5)
 ```

--- a/docs/modules/stimulus.md
+++ b/docs/modules/stimulus.md
@@ -80,19 +80,29 @@ sb.create_assemblies(
 
 ### Generate Stimulus
 
-Once you have assemblies, generate a stimulus file:
+Use `generate_stimulus()` to create time-varying firing patterns for your assemblies. 
+First create assemblies with `create_assemblies()`, then generate stimulus patterns:
 
 ```python
+# Create assembly first
+sb.create_assemblies(
+    name='stim_groups',
+    network_name='my_network',
+    method='property',
+    property_name='pulse_group_id'
+)
+
+# Then generate stimulus
 sb.generate_stimulus(
     output_path='stimulus.h5',
-    pattern_type='long',               # Firing pattern type
-    assembly_name='random_groups',     # Use this assembly group
-    population='stimulus',             # Population name in BMTK
-    firing_rate=(0.0, 50.0, 0.0),    # (off_rate, burst_rate, silent_rate)
-    t_start=1.0,                       # Start time (seconds)
-    t_stop=15.0,                       # End time (seconds)
-    on_time=1.0,                       # Duration of active period
-    off_time=0.5                       # Duration of silent period
+    pattern_type='long',
+    assembly_name='stim_groups',    # Use pre-created assembly
+    population='stimulus',
+    firing_rate=(0.0, 50.0, 0.0),
+    t_start=1.0,
+    t_stop=15.0,
+    on_time=1.0,
+    off_time=0.5
 )
 ```
 
@@ -285,38 +295,41 @@ sb.create_assemblies(
 
 ## Advanced Features
 
-### Generate Baseline Activity
+### Generate Background Activity
 
-Create background activity across all nodes in a network with a specified firing rate distribution.
+Create background spiking activity grouped by node properties with mixed distribution types on a per-group basis.
 
+**Population-specific rates**:
 ```python
-sb.generate_baseline(
-    output_path='baseline.h5',
-    network_name='cortex',
-    distribution='lognormal',  # 'lognormal', 'normal', or 'constant'
-    mean=20.0,                 # Mean firing rate (Hz)
-    stdev=2.0,                 # Standard deviation
+params = {
+    'PN': {'mean_firing_rate': 20.0, 'stdev': 2.0},   # lognormal distribution
+    'PV': {'mean_firing_rate': 30.0},                  # constant rate (no stdev)
+    'SST': {'mean_firing_rate': 15.0, 'stdev': 1.5}   # lognormal distribution
+}
+
+sb.generate_background(
+    output_path='background.h5',
+    network_name='input',
+    population_params=params,
     t_start=0.0,
     t_stop=15.0
 )
 ```
 
-### Generate Population-Specific Shell Input
-
-Create background activity with different firing rates for each population.
-
+**Group by custom property** (e.g., layer instead of pop_name):
 ```python
-shell_params = {
-    'PN': (20.0, 2.0),   # (mean, stdev) Hz for PN cells
-    'PV': (30.0, 3.0),   # (mean, stdev) Hz for PV cells
-    'SST': (15.0, 1.5)   # (mean, stdev) Hz for SST cells
+layer_params = {
+    'L1': {'mean_firing_rate': 10.0, 'stdev': 1.0},
+    'L2/3': {'mean_firing_rate': 15.0, 'stdev': 2.0},
+    'L4': {'mean_firing_rate': 25.0},  # constant rate
+    'L5': {'mean_firing_rate': 20.0, 'stdev': 1.8}
 }
 
-sb.generate_shell_input(
-    output_path='shell.h5',
-    network_name='input',
-    shell_params=shell_params,
-    distribution='lognormal',
+sb.generate_background(
+    output_path='layer_background.h5',
+    network_name='cortex',
+    population_params=layer_params,
+    groupby='layer',  # Use 'layer' column instead of 'pop_name'
     t_start=0.0,
     t_stop=15.0
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="bmtool",
-    version="0.8.0",
+    version="0.8.1",
     author="Neural Engineering Laboratory at the University of Missouri",
     author_email="gregglickert@mail.missouri.edu",
     description="BMTool",


### PR DESCRIPTION
- Implemented generate_background method to create baseline spiking activity for network nodes, allowing for population-specific firing rates and distributions.
- Updated documentation to reflect new method and usage examples.
- Refactored stimulus tutorial to demonstrate the use of generate_background for generating shell input and baseline activity.
- Bumped version to 0.8.1 in setup.py.


## Type of Change
- [ ] Bug fix
- [x] New feature/analysis
- [x] Documentation update
- [ ] Refactor (code changes that neither fix a bug nor add a feature)
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation